### PR TITLE
Chore: Update wrong HTTP method on manage subscription link endpoint

### DIFF
--- a/dist/paystack.yaml
+++ b/dist/paystack.yaml
@@ -1581,7 +1581,7 @@ paths:
         default:
           description: Server error
   '/subscription/{code}/manage/link':
-    post:
+    get:
       tags:
         - Subscription
       summary: Generate Update Subscription Link

--- a/main/resources/subscription/manage-link.yaml
+++ b/main/resources/subscription/manage-link.yaml
@@ -1,4 +1,4 @@
-post:
+get:
   tags:
     - Subscription
   summary: Generate Update Subscription Link

--- a/sdk/paystack.yaml
+++ b/sdk/paystack.yaml
@@ -1194,7 +1194,7 @@ paths:
         default:
           description: Server error
   /subscription/{code}/manage/link:
-    post:
+    get:
       tags:
         - Subscription
       summary: Generate Update Subscription Link


### PR DESCRIPTION
---
name: Update Manage Subscription Link HTTP Method
about: HTTP method change

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## What issue does this change solve?
The manage subscription link endpoint should have a GET method but was POST as mentioned in issue #14 


# Additional context
None